### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/dicklane/28fb6aac-67cf-4321-826d-662e33ae92c5/eaafbe0e-d62f-4ac6-b4b0-2e08154010ca/_apis/work/boardbadge/14316be2-de50-474b-8020-ce25dfbec3b5)](https://dev.azure.com/dicklane/28fb6aac-67cf-4321-826d-662e33ae92c5/_boards/board/t/eaafbe0e-d62f-4ac6-b4b0-2e08154010ca/Microsoft.RequirementCategory)
 # NC
 A CMS/Blog built with Python and Django/Wagtail. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/dicklane/28fb6aac-67cf-4321-826d-662e33ae92c5/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.